### PR TITLE
Update to fix HTTP endpoints

### DIFF
--- a/spring/spring-mvc-examples/spring-mvc-hibernate/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/spring/spring-mvc-examples/spring-mvc-hibernate/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,20 +1,20 @@
 <?xml  version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aop="http://www.springframework.org/schema/aop"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xmlns:jee="http://www.springframework.org/schema/jee"
-       xmlns:lang="http://www.springframework.org/schema/lang"
-       xmlns:p="http://www.springframework.org/schema/p"
-       xmlns:tx="http://www.springframework.org/schema/tx"
-       xmlns:util="http://www.springframework.org/schema/util"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-        http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-        http://www.springframework.org/schema/jee http://www.springframework.org/schema/jee/spring-jee.xsd
-        http://www.springframework.org/schema/lang http://www.springframework.org/schema/lang/spring-lang.xsd
-        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+       xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+       xmlns:aop="https://www.springframework.org/schema/aop"
+       xmlns:context="https://www.springframework.org/schema/context"
+       xmlns:jee="https://www.springframework.org/schema/jee"
+       xmlns:lang="https://www.springframework.org/schema/lang"
+       xmlns:p="https://www.springframework.org/schema/p"
+       xmlns:tx="https://www.springframework.org/schema/tx"
+       xmlns:util="https://www.springframework.org/schema/util"
+       xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+        https://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
+        https://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+        https://www.springframework.org/schema/jee https://www.springframework.org/schema/jee/spring-jee.xsd
+        https://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang.xsd
+        https://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd
+        https://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
  
     <context:annotation-config />
     <context:component-scan base-package="es.devcircus.springmvc_examples.springmvc_hibernate.contact" />


### PR DESCRIPTION
Some of the endpoints are still using HTTP that is insecure ... replaced with secure HTTP (HTTP with SSL/TLS) that exists

Details:

I found instances where the HTTP protocol is used instead of HTTPS (HTTP with TLS). According to the Common Weakness Enumeration organization this is a security weakness (https://cwe.mitre.org/data/definitions/319.html).